### PR TITLE
[ new ] auto completions

### DIFF
--- a/idris2-commands.el
+++ b/idris2-commands.el
@@ -850,7 +850,7 @@ type-correct, so loading will fail."
             (unless (null completions)
               (let ((choice (pcase completions
                               (`(,unique) unique)
-                              (_ (ido-completing-read "Multiple completions: " completions))))))
+                              (_ (ido-completing-read "Multiple completions: " completions)))))
                 (list start end (list (concat partial choice)) :exclusive 'no)))))))))
 
 (defun idris2-complete-keyword-at-point ()

--- a/idris2-commands.el
+++ b/idris2-commands.el
@@ -833,10 +833,12 @@ type-correct, so loading will fail."
     (cl-destructuring-bind (identifier start end) (idris2-identifier-backwards-from-point)
       (when identifier
         (let ((result (car (idris2-eval `(:repl-completions ,identifier)))))
-          (cl-destructuring-bind (completions _partial) result
+          (cl-destructuring-bind (completions partial) result
             (unless (null completions)
-              (list start end completions
-                    :exclusive 'no))))))))
+              (let ((choice (pcase completions
+                              (`(,unique) unique)
+                              (_ (ido-completing-read "Multiple completions: " completions))))))
+                (list start end (list (concat partial choice)) :exclusive 'no)))))))))
 
 (defun idris2-complete-keyword-at-point ()
   "Attempt to complete the symbol at point as an Idris2 keyword."
@@ -849,8 +851,7 @@ type-correct, so loading will fail."
                          (apply-partially #'string-prefix-p identifier)
                          all-idris2-keywords)))
         (unless (null candidates)
-          (list start end candidates
-                :exclusive 'no))))))
+          (list start end candidates :exclusive 'no))))))
 
 (defun idris2-list-holes ()
   "Get a list of currently-open holes"


### PR DESCRIPTION
The implementation is open to debate:

1. if the completion is unique then I commit to it
2. otherwise I use `ido` to let the user to pick the one they want

Shouldn't emacs already have this feature for its completion hooks?
Have I missed something?

In the REPL emacs automatically opens a "multiple completions possible, click on the one you want"
without me needing to use `ido` so I'm really confused. I'd be happy to accept better solutions.

This is a companion PR to https://github.com/idris-lang/Idris2/pull/2511