### PR TITLE
Kill buffer and it's window if the buffer was the only buffer in windows history.

### DIFF
--- a/idris2-common-utils.el
+++ b/idris2-common-utils.el
@@ -72,7 +72,11 @@ Lisp package.")
               ((bufferp buffer)
                buffer)
               (t (message "don't know how to kill buffer")))))
-    (when (and buf (buffer-live-p buf)) (kill-buffer buf))))
+    (when (and buf (buffer-live-p buf))
+      (let ((win (get-buffer-window buf)))
+        (kill-buffer buf)
+        (when (null (window-prev-buffers win))
+          (delete-window win))))))
 
 (defun idris2-minibuffer-respecting-message (text &rest args)
   "Display TEXT as a message, without hiding any minibuffer contents."

--- a/idris2-info.el
+++ b/idris2-info.el
@@ -110,9 +110,8 @@ Ensure that the buffer is in `idris2-info-mode'."
   "Exits the info window. Tries to go back to the previous window and buffer before it was opened."
   (interactive)
   (idris2-kill-buffer idris2-info-buffer-name)
-  (if (and idris2-buffer-to-return-to-from-info-buffer (buffer-live-p idris2-buffer-to-return-to-from-info-buffer))
-      (pop-to-buffer idris2-buffer-to-return-to-from-info-buffer `(display-buffer-reuse-window))
-    ())
+  (when (and idris2-buffer-to-return-to-from-info-buffer (buffer-live-p idris2-buffer-to-return-to-from-info-buffer))
+      (pop-to-buffer idris2-buffer-to-return-to-from-info-buffer `(display-buffer-reuse-window)))
   (setq idris2-buffer-to-return-to-from-info-buffer nil))
 
 (defun idris2-info-buffer-visible-p ()


### PR DESCRIPTION
Previously if we kill an Idris buffer Emacs would
preserve the window and copy another visible buffer into it which leads to not pleasant user experience.

**Before:**

https://user-images.githubusercontent.com/578608/200115499-220db022-027a-441a-b53f-d7c0ecc304dd.mp4

**After:**

https://user-images.githubusercontent.com/578608/20011b5613-8e3821fc-d387-474a-bcca-93587515e1e5.mp4

